### PR TITLE
Fixes version variable overwrite

### DIFF
--- a/cloud-pak-for-integration/byo-ocp-ipi/scripts/common.sh
+++ b/cloud-pak-for-integration/byo-ocp-ipi/scripts/common.sh
@@ -135,15 +135,15 @@ function cli-download() {
     fi
 
     if [[ -z ${3} ]]; then
-        VERSION="stable-4.12"
+        OC_VERSION="stable-4.12"
     else
-        VERSION="${3}"
+        OC_VERSION="${3}"
     fi
 
     ARCH=$(uname -m)
     OC_FILETYPE="linux"
     KUBECTL_FILETYPE="linux"
-    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
+    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${OC_VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
 
     log-output "INFO: Downloading and installing oc and kubectl"
     curl -sLo $TMP_DIR/openshift-client.tgz $OC_URL

--- a/cloud-pak-for-integration/cp4i/scripts/common.sh
+++ b/cloud-pak-for-integration/cp4i/scripts/common.sh
@@ -115,15 +115,15 @@ function cli-download() {
     fi
     
     if [[ -z ${3} ]]; then
-        VERSION="stable-4.12"
+        OC_VERSION="stable-4.12"
     else
-        VERSION="${3}"
+        OC_VERSION="${3}"
     fi
 
     ARCH=$(uname -m)
     OC_FILETYPE="linux"
     KUBECTL_FILETYPE="linux"
-    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
+    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${OC_VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
 
     log-output "INFO: Downloading and installing oc and kubectl"
     curl -sLo $TMP_DIR/openshift-client.tgz $OC_URL

--- a/cloud-pak-for-integration/with-aro/cp4i/scripts/common.sh
+++ b/cloud-pak-for-integration/with-aro/cp4i/scripts/common.sh
@@ -123,15 +123,15 @@ function cli-download() {
     fi
 
     if [[ -z ${3} ]]; then
-        VERSION="stable-4.12"
+        OC_VERSION="stable-4.12"
     else
-        VERSION="${3}"
+        OC_VERSION="${3}"
     fi
 
     ARCH=$(uname -m)
     OC_FILETYPE="linux"
     KUBECTL_FILETYPE="linux"
-    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
+    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${OC_VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
 
     log-output "INFO: Downloading and installing oc and kubectl"
     curl -sLo $TMP_DIR/openshift-client.tgz $OC_URL

--- a/cloud-pak-for-integration/with-aro/odf/scripts/common.sh
+++ b/cloud-pak-for-integration/with-aro/odf/scripts/common.sh
@@ -123,15 +123,15 @@ function cli-download() {
     fi
 
     if [[ -z ${3} ]]; then
-        VERSION="stable-4.12"
+        OC_VERSION="stable-4.12"
     else
-        VERSION="${3}"
+        OC_VERSION="${3}"
     fi
 
     ARCH=$(uname -m)
     OC_FILETYPE="linux"
     KUBECTL_FILETYPE="linux"
-    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
+    OC_URL="https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${OC_VERSION}/openshift-client-${OC_FILETYPE}.tar.gz"
 
     log-output "INFO: Downloading and installing oc and kubectl"
     curl -sLo $TMP_DIR/openshift-client.tgz $OC_URL


### PR DESCRIPTION
During testing, found that the VERSION variable used in the CP4I navigator instance creation gets overridden by the earlier change to download a default openshift oc client. This pull request fixes that by renaming the variable to OC_VERSION in the cli-download function.